### PR TITLE
React 17 Support

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,7 @@
     "types": "index.d.ts",
     "dependencies": {},
     "peerDependencies": {
-        "react": "^16.8.6",
+        "react": ">=16.8.6",
         "uplot": "^1.6.7"
     },
     "devDependencies": {


### PR DESCRIPTION
This allows to use uplot-react with React versions greater than 16.

See issue #7.