### PR TITLE
Updating dev dependencies for the react eco

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -35,8 +35,8 @@
     "devDependencies": {
         "@types/react": "^16.8.25",
         "@types/react-dom": "^16.8.5",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6",
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6",
         "uplot": "^1.6.7",
         "uplot-wrappers-common": "1.0.2"
     }


### PR DESCRIPTION
Proposing to update the react ecosystem to a free version ahead, the library downstream is rather safe for upper versions, and i cannot use react 17 with no reason.