### PR TITLE
DOCS: Npm collaborator fix

### DIFF
--- a/svelte/package.json
+++ b/svelte/package.json
@@ -2,11 +2,15 @@
 	"name": "uplot-svelte",
 	"version": "1.2.1",
 	"description": "Svelte wrapper for uPlot that allows you to work with charts declaratively inside your favorite framework",
-	"author": "Kiril Panayotov <contact@zakrok.dev> (https://zakrok.dev)",
+	"author": "Kiril Panayotov <contact@zakrok.dev>",
 	"contributors": [
 		{
 			"name": "Sergey Kalinichev",
 			"email": "kalinichev.so.0@gmail.com"
+		},
+		{
+			"name": "Kiril Panayotov",
+			"email": "contact@zakrok.dev"
 		}
 	],
 	"license": "MIT",


### PR DESCRIPTION
Greetings,

I apologize for the oversight, npm was not displaying the package in my profile for some reason. If it's possible, you could add me as a collaborator so that on the next update it does display it. 

Again apologies for the trouble. 

P.S. I tested using the published package on my own project and it works just fine, so webpack indeed worked with Svelte!